### PR TITLE
Ported 2.8 to Disruptor.Net

### DIFF
--- a/Backlog.txt
+++ b/Backlog.txt
@@ -1,5 +1,7 @@
 - add proper documentation in the wiki
 - port OnePublisherToOneProcessorUniCastRawThroughputTest
 - port OnePublisherToThreeWorkerPoolThroughputTest
+- port ShouldSerialisePublishingOnTheCursorWhenTwoThreadsArePublishing
+- port ShouldSerialisePublishingOnTheCursorWhenTwoThreadsArePublishingWithBatches
 - port the DSL Tests
 - improve README with samples, how to contrbute, etc

--- a/Disruptor.Tests/Collections/HistogramTests.cs
+++ b/Disruptor.Tests/Collections/HistogramTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Disruptor.Collections;
 using NUnit.Framework;
 
@@ -149,6 +150,14 @@ namespace Disruptor.Tests.Collections
             AddObservations(_histogram, 1L, 7L, 10L, 10L, 11L, 144L);
 
             Assert.AreEqual(1L, _histogram.Min);
+        }
+
+        [Test]
+        public void ShouldGetMinAndMaxOfSingleObservation()
+        {
+            AddObservations(_histogram, 10L);
+            Assert.AreEqual(10L, _histogram.Min);
+            Assert.AreEqual(10L, _histogram.Max);
         }
 
         [Test]

--- a/Disruptor.Tests/MultiThreadedClaimStrategyTests.cs
+++ b/Disruptor.Tests/MultiThreadedClaimStrategyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using Moq;
@@ -15,6 +16,12 @@ namespace Disruptor.Tests
         public void SetUp()
         {
             _claimStrategy = new MultiThreadedClaimStrategy(BufferSize);
+        }
+            
+        [Test]
+        public void ShouldNotCreateBufferWithNonPowerOf2()
+        {
+            Assert.Throws<ArgumentException>(() => new MultiThreadedClaimStrategy(1024, 129));
         }
 
         [Test]
@@ -200,7 +207,7 @@ namespace Disruptor.Tests
         }
 
         //[Test]
-        //public void shouldSerialisePublishingOnTheCursorWhenTwoThreadsArePublishing()
+        //public void ShouldSerialisePublishingOnTheCursorWhenTwoThreadsArePublishing()
         //{
         //    Sequence dependentSequence = new Sequence(Sequencer.InitialCursorValue);
         //    Sequence[] dependentSequences = { dependentSequence };
@@ -277,6 +284,60 @@ namespace Disruptor.Tests
         //    // One thread can end up setting both sequences.
         //    assertThat(threadSequences.get(0), is(notNullValue()));
         //    assertThat(threadSequences.get(1), is(notNullValue()));
+        //}
+
+        //@Test
+        //public void shouldSerialisePublishingOnTheCursorWhenTwoThreadsArePublishingWithBatches() throws InterruptedException
+        //{
+        //    final Sequence[] dependentSequences = {};
+        //    final Sequence cursor = new Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+
+        //    final CountDownLatch orderingLatch = new CountDownLatch(2);
+        //    final int iterations = 1000000;
+        //    final int batchSize = 44;
+
+        //    final Runnable publisherOne = new Runnable()
+        //    {
+        //        @Override
+        //        public void run()
+        //        {
+        //            int counter = iterations;
+        //            while (-1 != --counter)
+        //            {
+        //                final long sequence = claimStrategy.incrementAndGet(batchSize, dependentSequences);
+        //                claimStrategy.serialisePublishing(sequence, cursor, batchSize);
+        //            }
+                
+        //            orderingLatch.countDown();
+        //        }
+        //    };
+
+        //    final Runnable publisherTwo = new Runnable()
+        //    {
+        //        @Override
+        //        public void run()
+        //        {
+        //            int counter = iterations;
+        //            while (-1 != --counter)
+        //            {
+        //                final long sequence = claimStrategy.incrementAndGet(batchSize, dependentSequences);
+        //                claimStrategy.serialisePublishing(sequence, cursor, batchSize);
+        //            }
+                
+        //            orderingLatch.countDown();
+        //        }
+        //    };
+
+        //    Thread tOne = new Thread(publisherOne);
+        //    tOne.setDaemon(true);
+        //    Thread tTwo = new Thread(publisherTwo);
+        //    tTwo.setDaemon(true);
+        //    tOne.setName("tOne");
+        //    tTwo.setName("tTwo");
+        //    tOne.start();
+        //    tTwo.start();
+        
+        //    assertThat("Timed out waiting for threads", orderingLatch.await(10, TimeUnit.SECONDS), is(true));
         //}
     }
 }

--- a/Disruptor/Collections/Histogram.cs
+++ b/Disruptor/Collections/Histogram.cs
@@ -118,7 +118,7 @@ namespace Disruptor.Collections
             {
                 _minValue = value;
             }
-            else if (value > _maxValue)
+            if (value > _maxValue)
             {
                 _maxValue = value;
             }

--- a/Disruptor/Dsl/EventProcessorRepository.cs
+++ b/Disruptor/Dsl/EventProcessorRepository.cs
@@ -26,7 +26,7 @@ namespace Disruptor.Dsl
         {
             get
             {
-                return (from eventProcessorInfo in _eventProcessorInfoByHandler.Values
+                return (from eventProcessorInfo in _eventProcessorInfoByEventProcessor.Values
                         where eventProcessorInfo.IsEndOfChain
                         select eventProcessorInfo.EventProcessor).ToArray();
             }

--- a/Disruptor/Util.cs
+++ b/Disruptor/Util.cs
@@ -10,17 +10,28 @@
         /// </summary>
         /// <param name="x">Value to round up</param>
         /// <returns>The next power of 2 from x inclusive</returns>
-        public static int CeilingNextPowerOfTwo(int x)
+        public static int CeilingNextPowerOfTwo(this int x)
         {
             var result = 2;
 
             while (result < x)
             {
-                result *= 2;
+                result <<= 1;
             }
 
             return result;
         }
+
+        /// <summary>
+        /// Test whether a given integer is a power of 2 
+        /// </summary>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static bool IsPowerOf2(this int x)
+        {
+            return x > 0 && (x & (x - 1)) == 0;
+        }
+
 
         /// <summary>
         /// Get the minimum sequence from an array of <see cref="Sequence"/>s.

--- a/Version.cs
+++ b/Version.cs
@@ -16,7 +16,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("http://github.com/odeheurles/Disruptor-net/network")]
 [assembly: AssemblyProduct("Disruptor")]
 [assembly: AssemblyCopyright("Copyright © disruptor-net")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
-
-
+[assembly: AssemblyVersion("2.8.0")]
+[assembly: AssemblyFileVersion("2.8.0")]


### PR DESCRIPTION
- disruptor git commit bdde8ccac311f0b7570468180638cf27f3c93a25
- Version.cs now reflects the Disruptor version, I see no reason to keep a separate version #
