### PR TITLE
Made tasks long-running.

### DIFF
--- a/Disruptor/Dsl/Disruptor.cs
+++ b/Disruptor/Dsl/Disruptor.cs
@@ -164,7 +164,7 @@ namespace Disruptor.Dsl
             {
                 var eventProcessor = eventProcessorInfo.EventProcessor;
 
-                Task.Factory.StartNew(eventProcessor.Run, CancellationToken.None, TaskCreationOptions.None, _taskScheduler);
+                Task.Factory.StartNew(eventProcessor.Run, CancellationToken.None, TaskCreationOptions.LongRunning, _taskScheduler);
             }
 
             return _ringBuffer;

--- a/Disruptor/WorkerPool.cs
+++ b/Disruptor/WorkerPool.cs
@@ -119,7 +119,7 @@ namespace Disruptor
                 var workProcessor = _workProcessors[i];
                 workProcessor.Sequence.Value = cursor;
 
-                Task.Factory.StartNew(workProcessor.Run, CancellationToken.None, TaskCreationOptions.None, taskScheduler);
+                Task.Factory.StartNew(workProcessor.Run, CancellationToken.None, TaskCreationOptions.LongRunning, taskScheduler);
             }
 
             return _ringBuffer;


### PR DESCRIPTION
Hi! I've made the tasks long-running. It's needed because otherwise it takes ages for the Disruptor to start up, if it has many workers.

Since all the processors have the while(true) loops, I think marking tasks as long-running is required.