### PR TITLE
Optimizations

### DIFF
--- a/src/Disruptor.Benchmarks/RingBufferFields.cs
+++ b/src/Disruptor.Benchmarks/RingBufferFields.cs
@@ -1,39 +1,40 @@
 using System;
 using System.Runtime.InteropServices;
+using static Disruptor.Constants;
 
 namespace Disruptor
 {
-    [StructLayout(LayoutKind.Explicit, Size = 144)]
+    [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 2 + 32)]
     internal struct RingBufferFields
     {
         public static readonly int BufferPad = 128 / IntPtr.Size;
 
-        // padding: 56
+        // padding: CacheLineSize
 
-        [FieldOffset(56)]
+        [FieldOffset(CacheLineSize)]
         public object[] Entries;
 
-        [FieldOffset(64)]
+        [FieldOffset(CacheLineSize + 8)]
         public long IndexMask;
 
-        [FieldOffset(72)]
+        [FieldOffset(CacheLineSize + 16)]
         public int BufferSize;
 
-        [FieldOffset(76)]
+        [FieldOffset(CacheLineSize + 20)]
         public RingBufferSequencerType SequencerType;
 
         // padding: 3
 
-        [FieldOffset(80)]
+        [FieldOffset(CacheLineSize + 24)]
         public SingleProducerSequencer SingleProducerSequencer;
 
-        [FieldOffset(80)]
+        [FieldOffset(CacheLineSize + 24)]
         public MultiProducerSequencer MultiProducerSequencer;
 
-        [FieldOffset(80)]
+        [FieldOffset(CacheLineSize + 24)]
         public ISequencer Sequencer;
 
-        // padding: 56
+        // padding: CacheLineSize
 
         public enum RingBufferSequencerType : byte
         {

--- a/src/Disruptor.PerfTests/Disruptor.PerfTests.csproj
+++ b/src/Disruptor.PerfTests/Disruptor.PerfTests.csproj
@@ -4,15 +4,19 @@
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <OutputType>exe</OutputType>
     <SignAssembly>false</SignAssembly>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <TieredCompilation>False</TieredCompilation>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Disruptor.Tests\Disruptor.Tests.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="HdrHistogram" Version="2.5.0" />
+    <PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 

--- a/src/Disruptor.PerfTests/Program.cs
+++ b/src/Disruptor.PerfTests/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -10,6 +11,7 @@ namespace Disruptor.PerfTests
     {
         public static void Main(string[] args)
         {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.RealTime;
             if (!Options.TryParse(args, out var options))
             {
                 Options.PrintUsage();

--- a/src/Disruptor.PerfTests/Program.cs
+++ b/src/Disruptor.PerfTests/Program.cs
@@ -11,7 +11,6 @@ namespace Disruptor.PerfTests
     {
         public static void Main(string[] args)
         {
-            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.RealTime;
             if (!Options.TryParse(args, out var options))
             {
                 Options.PrintUsage();

--- a/src/Disruptor.PerfTests/Sequenced/OneToOneSequencedThreadAffinityThroughputTest.cs
+++ b/src/Disruptor.PerfTests/Sequenced/OneToOneSequencedThreadAffinityThroughputTest.cs
@@ -63,7 +63,7 @@ namespace Disruptor.PerfTests.Sequenced
             _eventHandler.Reset(expectedCount);
             var processorTask = _executor.Execute(() =>
             {
-                using var _ = ThreadAffinityUtil.SetThreadAffinity(0);
+                using var _ = ThreadAffinityUtil.SetThreadAffinity(2);
 
                 Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
@@ -72,18 +72,24 @@ namespace Disruptor.PerfTests.Sequenced
 
             _batchEventProcessor.WaitUntilStarted(TimeSpan.FromSeconds(5));
 
-            using var _ = ThreadAffinityUtil.SetThreadAffinity(1);
+            using var _ = ThreadAffinityUtil.SetThreadAffinity(4);
 
             Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             sessionContext.Start();
 
             var ringBuffer = _ringBuffer;
-
+            long sum = 0;
             for (long i = 0; i < _iterations; i++)
             {
                 var s = ringBuffer.Next();
                 ringBuffer[s].Value = i;
+                sum += i;
+                sum += i % 2;
+                sum += i % 3;
+                sum += i % 4;
+                sum += i % 5;
+                sum += i % 6;
                 ringBuffer.Publish(s);
             }
 

--- a/src/Disruptor/Disruptor.csproj
+++ b/src/Disruptor/Disruptor.csproj
@@ -6,6 +6,8 @@
     <IsPackable>true</IsPackable>
     <PackageId>Disruptor</PackageId>
     <NoWarn>1701;1702;1591</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Disruptor/ProcessingSequenceBarrier.cs
+++ b/src/Disruptor/ProcessingSequenceBarrier.cs
@@ -29,6 +29,7 @@ namespace Disruptor
             _dependentSequence = SequenceGroups.CreateReadOnlySequence(cursorSequence, dependentSequences);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long WaitFor(long sequence)
         {
             CheckAlert();

--- a/src/Disruptor/RingBuffer.cs
+++ b/src/Disruptor/RingBuffer.cs
@@ -20,7 +20,7 @@ namespace Disruptor
         protected object _entries;
 
         [FieldOffset(64)]
-        protected long _indexMask;
+        protected int _indexMask;
 
         [FieldOffset(72)]
         protected int _bufferSize;
@@ -46,19 +46,19 @@ namespace Disruptor
             {
                 throw new ArgumentException("bufferSize must not be less than 1");
             }
-            if (!_bufferSize.IsPowerOf2())
+            if (!((int)_bufferSize).IsPowerOf2())
             {
                 throw new ArgumentException("bufferSize must be a power of 2");
             }
 
             _entries = Array.CreateInstance(eventType, _bufferSize + 2 * bufferPad);
-            _indexMask = _bufferSize - 1;
+            _indexMask = (int)(_bufferSize - 1);
         }
 
         /// <summary>
         /// Gets the size of the buffer.
         /// </summary>
-        public int BufferSize => _bufferSize;
+        public int BufferSize => (int)_bufferSize;
 
         /// <summary>
         /// Given specified <paramref name="requiredCapacity"/> determines if that amount of space

--- a/src/Disruptor/RingBuffer.cs
+++ b/src/Disruptor/RingBuffer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Disruptor.Constants;
 
 namespace Disruptor
 {
@@ -9,26 +10,26 @@ namespace Disruptor
     ///
     /// <see cref="RingBuffer{T}"/> and <see cref="ValueRingBuffer{T}"/>.
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 288)]
+    [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 2 + 32)]
     public abstract class RingBuffer : ICursored
     {
         protected static readonly int _bufferPadRef = Util.GetRingBufferPaddingEventCount(IntPtr.Size);
 
-        // padding: 128
+        // padding: CacheLineSize
 
-        [FieldOffset(128)]
+        [FieldOffset(CacheLineSize)]
         protected object _entries;
 
-        [FieldOffset(136)]
+        [FieldOffset(CacheLineSize + 8)]
         protected int _indexMask;
 
-        [FieldOffset(144)]
+        [FieldOffset(CacheLineSize + 16)]
         protected int _bufferSize;
 
-        [FieldOffset(152)]
+        [FieldOffset(CacheLineSize + 24)]
         protected SequencerDispatcher _sequencerDispatcher; // includes 7 bytes of padding
 
-        // padding: 128
+        // padding: CacheLineSize
 
         /// <summary>
         /// Construct a RingBuffer with the full option set.

--- a/src/Disruptor/RingBuffer.cs
+++ b/src/Disruptor/RingBuffer.cs
@@ -9,26 +9,26 @@ namespace Disruptor
     ///
     /// <see cref="RingBuffer{T}"/> and <see cref="ValueRingBuffer{T}"/>.
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 148)]
+    [StructLayout(LayoutKind.Explicit, Size = 288)]
     public abstract class RingBuffer : ICursored
     {
         protected static readonly int _bufferPadRef = Util.GetRingBufferPaddingEventCount(IntPtr.Size);
 
-        // padding: 56
+        // padding: 128
 
-        [FieldOffset(56)]
+        [FieldOffset(128)]
         protected object _entries;
 
-        [FieldOffset(64)]
+        [FieldOffset(136)]
         protected int _indexMask;
 
-        [FieldOffset(72)]
+        [FieldOffset(144)]
         protected int _bufferSize;
 
-        [FieldOffset(80)]
+        [FieldOffset(152)]
         protected SequencerDispatcher _sequencerDispatcher; // includes 7 bytes of padding
 
-        // padding: 52
+        // padding: 128
 
         /// <summary>
         /// Construct a RingBuffer with the full option set.
@@ -58,7 +58,7 @@ namespace Disruptor
         /// <summary>
         /// Gets the size of the buffer.
         /// </summary>
-        public int BufferSize => (int)_bufferSize;
+        public int BufferSize => _bufferSize;
 
         /// <summary>
         /// Given specified <paramref name="requiredCapacity"/> determines if that amount of space

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Disruptor.Dsl;
 
 namespace Disruptor
@@ -137,10 +138,7 @@ namespace Disruptor
         public T this[long sequence]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return Util.Read<T>(_entries, _bufferPadRef + (int)(sequence & _indexMask));
-            }
+            get => Util.Read<T>(_entries, _bufferPadRef + (unchecked((int)sequence) & _indexMask));
         }
 
         /// <summary>

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -138,10 +138,7 @@ namespace Disruptor
         public T this[long sequence]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return Util.Read<T>(_entries, _bufferPadRef + (int) (unchecked((int) sequence) & _indexMask));
-            }
+            get => Util.Read<T>(_entries, _bufferPadRef + (unchecked((int) sequence) & _indexMask));
         }
 
         /// <summary>

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -138,7 +138,10 @@ namespace Disruptor
         public T this[long sequence]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Util.Read<T>(_entries, _bufferPadRef + (unchecked((int)sequence) & _indexMask));
+            get
+            {
+                return Util.Read<T>(_entries, _bufferPadRef + (int) (unchecked((int) sequence) & _indexMask));
+            }
         }
 
         /// <summary>

--- a/src/Disruptor/Sequence.cs
+++ b/src/Disruptor/Sequence.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using static Disruptor.Constants;
 
 namespace Disruptor
 {
@@ -12,7 +13,7 @@ namespace Disruptor
     /// <p>Also attempts to be more efficient with regards to false
     /// sharing by adding padding around the volatile field.</p>
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 120)]
+    [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 2 + 8)]
     public class Sequence : ISequence
     {
         /// <summary>
@@ -20,13 +21,13 @@ namespace Disruptor
         /// </summary>
         public const long InitialCursorValue = -1;
 
-        // padding: 56
+        // padding: CacheLineSize
 
-        [FieldOffset(56)]
+        [FieldOffset(CacheLineSize)]
         // volatile in the Java version => always use Volatile.Read/Write or Interlocked methods to access this field
         private long _value;
 
-        // padding: 56
+        // padding: CacheLineSize
 
         /// <summary>
         /// Construct a new sequence counter that can be tracked across threads.
@@ -61,7 +62,7 @@ namespace Disruptor
 
         /// <summary>
         /// Performs a volatile write of this sequence.  The intent is a Store/Store barrier between this write and any previous
-        /// write and a Store/Load barrier between this write and any subsequent volatile read. 
+        /// write and a Store/Load barrier between this write and any subsequent volatile read.
         /// </summary>
         /// <param name="value"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Disruptor/SingleProducerSequencer.cs
+++ b/src/Disruptor/SingleProducerSequencer.cs
@@ -3,39 +3,38 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Disruptor.Dsl;
+using static Disruptor.Constants;
 
 namespace Disruptor
 {
-    [StructLayout(LayoutKind.Explicit, Size = 192)]
+    [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 2 + 56)]
     public class SingleProducerSequencer : ISequencer
     {
-        // padding: 56
+        // padding: CacheLineSize
 
-        [FieldOffset(56)]
+        [FieldOffset(CacheLineSize)]
         private readonly IWaitStrategy _waitStrategy;
 
-        [FieldOffset(64)]
+        [FieldOffset(CacheLineSize + 8)]
         private readonly Sequence _cursor = new Sequence();
 
-        [FieldOffset(72)]
+        [FieldOffset(CacheLineSize + 16)]
         // volatile in the Java version => always use Volatile.Read/Write or Interlocked methods to access this field
         private ISequence[] _gatingSequences = new ISequence[0];
 
-        [FieldOffset(80)]
+        [FieldOffset(CacheLineSize + 24)]
         private readonly bool _isBlockingWaitStrategy;
 
-        [FieldOffset(88)]
+        [FieldOffset(CacheLineSize + 32)]
         private readonly long _bufferSize;
 
-        // padding: 3
-
-        [FieldOffset(96)]
+        [FieldOffset(CacheLineSize + 40)]
         private long _nextValue = Sequence.InitialCursorValue;
 
-        [FieldOffset(104)]
+        [FieldOffset(CacheLineSize + 48)]
         private long _cachedValue = Sequence.InitialCursorValue;
 
-        // padding: 56
+        // padding: CacheLineSize
 
         public SingleProducerSequencer(int bufferSize)
             : this(bufferSize, SequencerFactory.DefaultWaitStrategy())

--- a/src/Disruptor/SingleProducerSequencer.cs
+++ b/src/Disruptor/SingleProducerSequencer.cs
@@ -6,7 +6,7 @@ using Disruptor.Dsl;
 
 namespace Disruptor
 {
-    [StructLayout(LayoutKind.Explicit, Size = 160)]
+    [StructLayout(LayoutKind.Explicit, Size = 192)]
     public class SingleProducerSequencer : ISequencer
     {
         // padding: 56
@@ -22,17 +22,17 @@ namespace Disruptor
         private ISequence[] _gatingSequences = new ISequence[0];
 
         [FieldOffset(80)]
-        private readonly int _bufferSize;
-
-        [FieldOffset(84)]
         private readonly bool _isBlockingWaitStrategy;
+
+        [FieldOffset(88)]
+        private readonly long _bufferSize;
 
         // padding: 3
 
-        [FieldOffset(88)]
+        [FieldOffset(96)]
         private long _nextValue = Sequence.InitialCursorValue;
 
-        [FieldOffset(96)]
+        [FieldOffset(104)]
         private long _cachedValue = Sequence.InitialCursorValue;
 
         // padding: 56
@@ -69,7 +69,7 @@ namespace Disruptor
         /// <summary>
         /// <see cref="ISequenced.BufferSize"/>.
         /// </summary>
-        public int BufferSize => _bufferSize;
+        public int BufferSize => (int)_bufferSize;
 
         /// <summary>
         /// <see cref="ICursored.Cursor"/>.
@@ -133,6 +133,7 @@ namespace Disruptor
             return NextInternal(n);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal long NextInternal(int n)
         {
             long nextValue = _nextValue;
@@ -183,6 +184,7 @@ namespace Disruptor
             return TryNextInternal(n, out sequence);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryNextInternal(int n, out long sequence)
         {
             if (!HasAvailableCapacity(n, true))

--- a/src/Disruptor/UnmanagedRingBuffer.cs
+++ b/src/Disruptor/UnmanagedRingBuffer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Disruptor.Internal;
+using static Disruptor.Constants;
 
 namespace Disruptor
 {
@@ -10,27 +10,27 @@ namespace Disruptor
     ///
     /// <see cref="UnmanagedRingBuffer{T}"/>.
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 148)]
+    [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 2 + 40)]
     public abstract class UnmanagedRingBuffer : ICursored
     {
-        // padding: 56
+        // padding: CacheLineSize
 
-        [FieldOffset(56)]
+        [FieldOffset(CacheLineSize)]
         protected IntPtr _entries;
 
-        [FieldOffset(64)]
+        [FieldOffset(CacheLineSize + 8)]
         protected long _indexMask;
 
-        [FieldOffset(72)]
+        [FieldOffset(CacheLineSize + 16)]
         protected int _eventSize;
 
-        [FieldOffset(76)]
+        [FieldOffset(CacheLineSize + 20)]
         protected int _bufferSize;
 
-        [FieldOffset(80)]
+        [FieldOffset(CacheLineSize + 24)]
         protected SequencerDispatcher _sequencerDispatcher; // includes 7 bytes of padding
 
-        // padding: 52
+        // padding: CacheLineSize
 
         /// <summary>
         /// Construct a UnmanagedRingBuffer with the full option set.

--- a/src/Disruptor/Util/AggressiveSpinWait.cs
+++ b/src/Disruptor/Util/AggressiveSpinWait.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Disruptor
@@ -25,6 +26,7 @@ namespace Disruptor
 
         private bool NextSpinWillYield => _count > _yieldThreshold || _isSingleProcessor;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SpinOnce()
         {
             if (NextSpinWillYield)

--- a/src/Disruptor/Util/Constants.cs
+++ b/src/Disruptor/Util/Constants.cs
@@ -5,5 +5,6 @@ namespace Disruptor
     internal static class Constants
     {
         internal const MethodImplOptions AggressiveOptimization = (MethodImplOptions)512;
+        internal const int CacheLineSize = 128;
     }
 }

--- a/src/Disruptor/Util/Util.cs
+++ b/src/Disruptor/Util/Util.cs
@@ -80,14 +80,15 @@ namespace Disruptor
         /// <param name="sequences">sequences to compare.</param>
         /// <param name="minimum">an initial default minimum.  If the array is empty this value will returned.</param>
         /// <returns>the minimum sequence found or lon.MaxValue if the array is empty.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long GetMinimumSequence(ISequence[] sequences, long minimum = long.MaxValue)
         {
             for (var i = 0; i < sequences.Length; i++)
             {
                 var sequence = sequences[i].Value;
-                minimum = Math.Min(minimum, sequence);
+                if (sequence < minimum)
+                    minimum = sequence;
             }
-
             return minimum;
         }
 

--- a/src/Disruptor/YieldingWaitStrategy.cs
+++ b/src/Disruptor/YieldingWaitStrategy.cs
@@ -1,14 +1,15 @@
-﻿using System.Threading;
+﻿using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Disruptor
 {
     /// <summary>
     /// Yielding strategy that uses a Thread.Yield() for <see cref="IEventProcessor"/>s waiting on a barrier
     /// after an initially spinning.
-    /// 
+    ///
     /// This strategy is a good compromise between performance and CPU resource without incurring significant latency spikes.
     /// </summary>
-    public sealed class YieldingWaitStrategy : INonBlockingWaitStrategy
+    public readonly struct YieldingWaitStrategy : INonBlockingWaitStrategy
     {
         private const int _spinTries = 100;
 
@@ -21,6 +22,7 @@ namespace Disruptor
         /// <param name="dependentSequence">dependents further back the chain that must advance first</param>
         /// <param name="barrier">barrier the <see cref="IEventProcessor"/> is waiting on.</param>
         /// <returns>the sequence that is available which may be greater than the requested sequence.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long WaitFor(long sequence, Sequence cursor, ISequence dependentSequence, ISequenceBarrier barrier)
         {
             long availableSequence;
@@ -41,6 +43,7 @@ namespace Disruptor
         {
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ApplyWaitMethod(ISequenceBarrier barrier, int counter)
         {
             barrier.CheckAlert();

--- a/src/Disruptor/YieldingWaitStrategy.cs
+++ b/src/Disruptor/YieldingWaitStrategy.cs
@@ -9,7 +9,7 @@ namespace Disruptor
     ///
     /// This strategy is a good compromise between performance and CPU resource without incurring significant latency spikes.
     /// </summary>
-    public readonly struct YieldingWaitStrategy : INonBlockingWaitStrategy
+    public sealed class YieldingWaitStrategy : INonBlockingWaitStrategy
     {
         private const int _spinTries = 100;
 
@@ -22,7 +22,6 @@ namespace Disruptor
         /// <param name="dependentSequence">dependents further back the chain that must advance first</param>
         /// <param name="barrier">barrier the <see cref="IEventProcessor"/> is waiting on.</param>
         /// <returns>the sequence that is available which may be greater than the requested sequence.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long WaitFor(long sequence, Sequence cursor, ISequence dependentSequence, ISequenceBarrier barrier)
         {
             long availableSequence;
@@ -43,7 +42,6 @@ namespace Disruptor
         {
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ApplyWaitMethod(ISequenceBarrier barrier, int counter)
         {
             barrier.CheckAlert();


### PR DESCRIPTION
Pinned benchmark goes from 109 to 173 Mops on my machine.

There are still some opportunities: tiered compilation is bad for non-pinned bench, we must warmup all static readonly primitives and find similar cases that go to hot loops unoptimized when TC is on.