### PR TITLE
Zero-extend int

### DIFF
--- a/src/Disruptor/Util/InternalUtil.cs
+++ b/src/Disruptor/Util/InternalUtil.cs
@@ -58,10 +58,13 @@ internal static class InternalUtil
         Ldloc_0(); // load the object pointer as a byref
 
         Ldarg(nameof(index));
+        Conv_U(); // zero extend
+
         Sizeof(typeof(object));
         Mul(); // index x sizeof(object)
 
         Call(MethodRef.PropertyGet(typeof(InternalUtil), nameof(ArrayDataOffset)));
+        Conv_U(); // zero extend
         Add(); // index x sizeof(object) +  ArrayDataOffset
 
         Add(); // array + index x sizeof(object) + ArrayDataOffset


### PR DESCRIPTION
Following Mendel's link to "Peanut butter" https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#peanut-butter.

This gives 2-3% on my machine on the same HT core. The bench with different physical cores became very unstable on my machine: jumping from 1xx to 280 (compared to my previous PR, which works as it did on the same machine). This is not related to this change, it jumps before the change as well.

Adding `ExtraWork` method, which was removed for some reason, every time is tedious so I have not, but it makes batching behavior more stable. So these numbers need to be double checked on different machines.