### PR TITLE
Handle explicit `OnBatchStart` implementations

### DIFF
--- a/src/Disruptor.Tests/Processing/EventProcessorFactoryTests.cs
+++ b/src/Disruptor.Tests/Processing/EventProcessorFactoryTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Disruptor.Processing;
 using Disruptor.Tests.Support;
@@ -23,5 +24,39 @@ public class EventProcessorFactoryTests
         {
             Assert.True(genericArgument.IsValueType, $"Generic argument {genericArgument.Name} is not a value type");
         }
+    }
+
+    [Test]
+    public void should_detect_explicit_implementation()
+    {
+        Assert.True(EventProcessorFactory.HasNonDefaultImplementation(typeof(TypeWithImplicitImplementation<int>), typeof(IInterface<int>), nameof(IInterface<int>.Method)));
+        Assert.True(EventProcessorFactory.HasNonDefaultImplementation(typeof(TypeWithExplicitImplementation<int>), typeof(IInterface<int>), nameof(IInterface<int>.Method)));
+        Assert.False(EventProcessorFactory.HasNonDefaultImplementation(typeof(TypeWithNoImplementation<int>), typeof(IInterface<int>), nameof(IInterface<int>.Method)));
+    }
+
+    [SuppressMessage("ReSharper", "UnusedTypeParameter")]
+    private interface IInterface<T>
+    {
+        void Method()
+        {
+        }
+    }
+
+    private class TypeWithImplicitImplementation<T> : IInterface<T>
+    {
+        public void Method()
+        {
+        }
+    }
+
+    private class TypeWithExplicitImplementation<T> : IInterface<T>
+    {
+        void IInterface<T>.Method()
+        {
+        }
+    }
+
+    private class TypeWithNoImplementation<T> : IInterface<T>
+    {
     }
 }

--- a/src/Disruptor.Tests/Processing/ValueEventProcessorTests.cs
+++ b/src/Disruptor.Tests/Processing/ValueEventProcessorTests.cs
@@ -308,6 +308,25 @@ public class ValueEventProcessorTests
         Assert.That(eventHandler.BatchSizeToCount.Keys, Has.No.Member(0));
     }
 
+    [Test]
+    public void ShouldCallBatchStartWithExplicitImplementation()
+    {
+        var signal = new CountdownEvent(1);
+
+        var eventHandler = new ExplicitBatchStartImplementationEventHandler(signal);
+        var eventProcessor = CreateEventProcessor(_ringBuffer, _sequenceBarrier, eventHandler);
+
+        _ringBuffer.PublishStubEvent(0);
+
+        var task = eventProcessor.Start();
+        Assert.IsTrue(signal.Wait(TimeSpan.FromSeconds(2)));
+
+        eventProcessor.Halt();
+
+        Assert.IsTrue(task.Wait(TimeSpan.FromSeconds(2)));
+        Assert.That(eventHandler.BatchCount, Is.EqualTo(1));
+    }
+
     private class DelegatingSequenceBarrier : ISequenceBarrier
     {
         private readonly ISequenceBarrier _target;
@@ -358,5 +377,27 @@ public class ValueEventProcessorTests
 
     internal class BatchAwareEventHandlerInternal : BatchAwareEventHandler
     {
+    }
+
+    public class ExplicitBatchStartImplementationEventHandler : IValueEventHandler<StubValueEvent>
+    {
+        private readonly CountdownEvent _signal;
+
+        public int BatchCount { get; private set; }
+
+        public ExplicitBatchStartImplementationEventHandler(CountdownEvent signal)
+        {
+            _signal = signal;
+        }
+
+        public void OnEvent(ref StubValueEvent data, long sequence, bool endOfBatch)
+        {
+            _signal.Signal();
+        }
+
+        void IValueEventHandler<StubValueEvent>.OnBatchStart(long batchSize)
+        {
+            ++BatchCount;
+        }
     }
 }

--- a/src/Disruptor/Processing/EventProcessor.cs
+++ b/src/Disruptor/Processing/EventProcessor.cs
@@ -31,7 +31,7 @@ public class EventProcessor<T, TDataProvider, TSequenceBarrier, TEventHandler, T
     private TDataProvider _dataProvider;
     private TSequenceBarrier _sequenceBarrier;
     private TEventHandler _eventHandler;
-    private TOnBatchStartEvaluator _onBatchStartInvoker;
+    private TOnBatchStartEvaluator _onBatchStartEvaluator;
     // ReSharper restore FieldCanBeMadeReadOnly.Local
 
     private readonly Sequence _sequence = new();
@@ -44,7 +44,7 @@ public class EventProcessor<T, TDataProvider, TSequenceBarrier, TEventHandler, T
         _dataProvider = dataProvider;
         _sequenceBarrier = sequenceBarrier;
         _eventHandler = eventHandler;
-        _onBatchStartInvoker = onBatchStartEvaluator;
+        _onBatchStartEvaluator = onBatchStartEvaluator;
 
         if (eventHandler is IEventProcessorSequenceAware sequenceAware)
             sequenceAware.SetSequenceCallback(_sequence);
@@ -153,7 +153,7 @@ public class EventProcessor<T, TDataProvider, TSequenceBarrier, TEventHandler, T
 
                 var availableSequence = waitResult.UnsafeAvailableSequence;
 
-                if (_onBatchStartInvoker.ShouldInvokeOnBatchStart(availableSequence, nextSequence))
+                if (_onBatchStartEvaluator.ShouldInvokeOnBatchStart(availableSequence, nextSequence))
                     _eventHandler.OnBatchStart(availableSequence - nextSequence + 1);
 
                 while (nextSequence <= availableSequence)


### PR DESCRIPTION
`OnBatchStart` methods on `IEventHandler<T>` and `IVaueEventHandler<T>` were not called when their implementation was explicit.
