### PR TITLE
Move `WaitUntilStarted` to `IEventProcessor`

### DIFF
--- a/src/Disruptor/Processing/IAsyncEventProcessor`1.cs
+++ b/src/Disruptor/Processing/IAsyncEventProcessor`1.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 
 namespace Disruptor.Processing;
@@ -14,12 +13,6 @@ public interface IAsyncEventProcessor<T> : IEventProcessor
     /// Asynchronously runs the processor.
     /// </summary>
     Task RunAsync();
-
-    /// <summary>
-    /// Waits before the event processor enters the <see cref="IEventProcessor.IsRunning"/> state.
-    /// </summary>
-    /// <param name="timeout">maximum wait duration</param>
-    void WaitUntilStarted(TimeSpan timeout);
 
     /// <summary>
     /// Set a new <see cref="IExceptionHandler{T}"/> for handling exceptions propagated out of the <see cref="IEventHandler{T}"/>

--- a/src/Disruptor/Processing/IEventProcessor.cs
+++ b/src/Disruptor/Processing/IEventProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Disruptor.Processing;
 
@@ -28,6 +29,12 @@ public interface IEventProcessor
     /// Starts this processor.
     /// </summary>
     Task Start(TaskScheduler taskScheduler, TaskCreationOptions taskCreationOptions);
+
+    /// <summary>
+    /// Waits before the event processor enters the <see cref="IEventProcessor.IsRunning"/> state.
+    /// </summary>
+    /// <param name="timeout">Maximum wait duration</param>
+    void WaitUntilStarted(TimeSpan timeout);
 
     /// <summary>
     /// Gets if the processor is running

--- a/src/Disruptor/Processing/IEventProcessor`1.cs
+++ b/src/Disruptor/Processing/IEventProcessor`1.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Disruptor.Processing;
+﻿namespace Disruptor.Processing;
 
 /// <summary>
 /// An event processor (<see cref="IEventProcessor"/>) for a reference-type ring buffer.
@@ -13,12 +11,6 @@ public interface IEventProcessor<T> : IEventProcessor
     /// Synchronously runs the processor.
     /// </summary>
     void Run();
-
-    /// <summary>
-    /// Waits before the event processor enters the <see cref="IEventProcessor.IsRunning"/> state.
-    /// </summary>
-    /// <param name="timeout">maximum wait duration</param>
-    void WaitUntilStarted(TimeSpan timeout);
 
     /// <summary>
     /// Set a new <see cref="IExceptionHandler{T}"/> for handling exceptions propagated out of the <see cref="IEventHandler{T}"/>

--- a/src/Disruptor/Processing/IValueEventProcessor.cs
+++ b/src/Disruptor/Processing/IValueEventProcessor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Disruptor.Processing;
+﻿namespace Disruptor.Processing;
 
 /// <summary>
 /// An event processor (<see cref="IEventProcessor"/>) for a value-type ring buffer.
@@ -13,12 +11,6 @@ public interface IValueEventProcessor<T> : IEventProcessor
     /// Synchronously runs the processor.
     /// </summary>
     void Run();
-
-    /// <summary>
-    /// Waits before the event processor enters the <see cref="IEventProcessor.IsRunning"/> state.
-    /// </summary>
-    /// <param name="timeout">maximum wait duration</param>
-    void WaitUntilStarted(TimeSpan timeout);
 
     /// <summary>
     /// Set a new <see cref="IValueExceptionHandler{T}"/> for handling exceptions propagated out of the <see cref="IValueEventHandler{T}"/>


### PR DESCRIPTION
All interfaces derived from `IEventProcessor` defined this method, and it made sense to put it beside `Start`.