### PR TITLE
Micro optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ launchSettings.json
 _ReSharper*/
 *.resharper
 [Tt]est[Rr]esult*
-.vs/*
+.vs/
 .vscode/*
 .idea
 BenchmarkDotNet.Artifacts/
@@ -40,3 +40,4 @@ BenchmarkDotNet.Artifacts/
 #Custom
 /build/nuget/
 local-*
+

--- a/src/Disruptor.Benchmarks/ObjectArrayBenchmarks.cs
+++ b/src/Disruptor.Benchmarks/ObjectArrayBenchmarks.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Disruptor.Benchmarks.Util;
 using Disruptor.Util;
@@ -35,10 +37,22 @@ public class ObjectArrayBenchmarks
     }
 
     [Benchmark]
+    public Event ReadOneMemoryMarshal()
+    {
+        return ReadMemoryMarshal<Event>(_array, NextSequence());
+    }
+
+    [Benchmark]
     public ReadOnlySpan<Event> ReadSpanIL()
     {
         var sequence = NextSequence();
         return InternalUtil.ReadSpan<Event>(_array, sequence, sequence);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T ReadMemoryMarshal<T>(object array, int index)
+    {
+        return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (nuint)(uint)index);
     }
 
     private int NextSequence() => _index++ & _mask;

--- a/src/Disruptor.Benchmarks/Program.cs
+++ b/src/Disruptor.Benchmarks/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Disruptor.Benchmarks.WaitStrategies;
 using ObjectLayoutInspector;
@@ -13,7 +14,7 @@ public static class Program
     {
         var benchmarkSwitcher = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
         benchmarkSwitcher.Run(
-            config: DefaultConfig.Instance.WithOption(ConfigOptions.JoinSummary, true),
+            config: DefaultConfig.Instance.WithOption(ConfigOptions.JoinSummary, true).AddJob(Job.Default.WithEnvironmentVariables(new EnvironmentVariable("DOTNET_TieredPGO", "0"))),
             args: args
         );
     }

--- a/src/Disruptor.PerfTests/Disruptor.PerfTests.csproj
+++ b/src/Disruptor.PerfTests/Disruptor.PerfTests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <SignAssembly>false</SignAssembly>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <TieredCompilation>False</TieredCompilation>
-    <NoWarn>NU1903</NoWarn>
+    <NoWarn>NU1903;NU1510</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,10 +15,6 @@
 <!--    <StartupObject>Disruptor.PerfTests.PerfTestTypePrinter</StartupObject>-->
   </PropertyGroup>
 
-  <PropertyGroup>
-    <PublishAot>true</PublishAot>
-    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Disruptor.Testing\Disruptor.Testing.csproj" />

--- a/src/Disruptor.PerfTests/Latency/OneWay/OneWaySequencedLatencyTest.cs
+++ b/src/Disruptor.PerfTests/Latency/OneWay/OneWaySequencedLatencyTest.cs
@@ -11,7 +11,7 @@ namespace Disruptor.PerfTests.Latency.OneWay;
 public class OneWaySequencedLatencyTest : ILatencyTest, IDisposable
 {
     private const int _bufferSize = 1024;
-    private const long _iterations = 100 * 1000 * 30;
+    private const long _iterations = 100 * 1000 * 10;
 
     private static readonly long _pause = StopwatchUtil.GetTimestampFromMicroseconds(10);
     private readonly ProgramOptions _options;
@@ -48,7 +48,7 @@ public class OneWaySequencedLatencyTest : ILatencyTest, IDisposable
             var now = Stopwatch.GetTimestamp();
             while (now < next)
             {
-                Thread.Yield();
+                Thread.SpinWait(1);
                 now = Stopwatch.GetTimestamp();
             }
 

--- a/src/Disruptor.PerfTests/Latency/OneWay/OneWaySequencedLatencyTest.cs
+++ b/src/Disruptor.PerfTests/Latency/OneWay/OneWaySequencedLatencyTest.cs
@@ -13,7 +13,7 @@ public class OneWaySequencedLatencyTest : ILatencyTest, IDisposable
     private const int _bufferSize = 1024;
     private const long _iterations = 100 * 1000 * 10;
 
-    private static readonly long _pause = StopwatchUtil.GetTimestampFromMicroseconds(10);
+    private static readonly long _pause = StopwatchUtil.GetTimestampFromMicroseconds(1);
     private readonly ProgramOptions _options;
     private readonly Disruptor<PerfEvent> _disruptor;
     private readonly Handler _handler;

--- a/src/Disruptor.PerfTests/Latency/PingPong/PingPongSequencedLatencyTest.cs
+++ b/src/Disruptor.PerfTests/Latency/PingPong/PingPongSequencedLatencyTest.cs
@@ -12,7 +12,7 @@ namespace Disruptor.PerfTests.Latency.PingPong;
 public class PingPongSequencedLatencyTest : ILatencyTest
 {
     private const int _bufferSize = 1024;
-    private const long _iterations = 100 * 1000 * 30;
+    private const long _iterations = 100 * 1000;
     private const long _pauseNanos = 1000;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Disruptor.PerfTests/LatencyTestSessionResult.cs
+++ b/src/Disruptor.PerfTests/LatencyTestSessionResult.cs
@@ -61,10 +61,10 @@ public class LatencyTestSessionResult
         if (_exception != null)
             return $"Run: FAILED: {_exception.Message}";
 
-        return $"Run: Duration: {Duration.TotalMilliseconds:N0} ms - GC: {Gen0} - {Gen1} - {Gen2} - Median: {PMS(50)} - P75: {PMS(75)} - P90: {PMS(90)} - P95: {PMS(95)} - P99: {PMS(99)}";
+        return $"Run: Duration: {Duration.TotalMilliseconds:N0} ms - GC: {Gen0} - {Gen1} - {Gen2} - Median: {PFmt(50)} - P75: {PFmt(75)} - P90: {PFmt(90)} - P95: {PFmt(95)} - P99: {PFmt(99)} - P99.9: {PFmt(99.9)} - P99.99: {PFmt(99.99)}";
 
-        string PMS(int percentile) => $"{P(percentile) / 1000.0:0.0} µs";
+        string PFmt(double percentile) => $"{P(percentile):N0} ns";
     }
 
-    public long P(int percentile) => Histogram.GetValueAtPercentile(percentile);
+    public long P(double percentile) => Histogram.GetValueAtPercentile(percentile);
 }

--- a/src/Disruptor.PerfTests/Program.cs
+++ b/src/Disruptor.PerfTests/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Disruptor.PerfTests;
@@ -7,6 +8,16 @@ public class Program
 {
     public static void Main(string[] args)
     {
+        try
+        {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
+        }
+        catch
+        {
+            ;
+        }
+
+
         if (!ProgramOptions.TryParse(args, out var options))
         {
             ProgramOptions.PrintUsage();

--- a/src/Disruptor.PerfTests/ProgramOptions.cs
+++ b/src/Disruptor.PerfTests/ProgramOptions.cs
@@ -9,8 +9,8 @@ namespace Disruptor.PerfTests;
 
 public class ProgramOptions
 {
-    public static int DefaultRunCountForLatencyTest { get; } = 30;
-    public static int DefaultRunCountForThroughputTest { get; } = 30;
+    public static int DefaultRunCountForLatencyTest { get; } = 10;
+    public static int DefaultRunCountForThroughputTest { get; } = 10;
     public static int[] DefaultCpuSet { get; } = Enumerable.Range(0, Environment.ProcessorCount).ToArray();
 
     public static IReadOnlyDictionary<string, Func<IWaitStrategy>> ConfigurableWaitStrategies { get; } = new Dictionary<string, Func<IWaitStrategy>>(StringComparer.OrdinalIgnoreCase)

--- a/src/Disruptor.PerfTests/ProgramOptions.cs
+++ b/src/Disruptor.PerfTests/ProgramOptions.cs
@@ -10,7 +10,7 @@ namespace Disruptor.PerfTests;
 public class ProgramOptions
 {
     public static int DefaultRunCountForLatencyTest { get; } = 3;
-    public static int DefaultRunCountForThroughputTest { get; } = 7;
+    public static int DefaultRunCountForThroughputTest { get; } = 30;
     public static int[] DefaultCpuSet { get; } = Enumerable.Range(0, Environment.ProcessorCount).ToArray();
 
     public static IReadOnlyDictionary<string, Func<IWaitStrategy>> ConfigurableWaitStrategies { get; } = new Dictionary<string, Func<IWaitStrategy>>(StringComparer.OrdinalIgnoreCase)

--- a/src/Disruptor.PerfTests/ProgramOptions.cs
+++ b/src/Disruptor.PerfTests/ProgramOptions.cs
@@ -9,7 +9,7 @@ namespace Disruptor.PerfTests;
 
 public class ProgramOptions
 {
-    public static int DefaultRunCountForLatencyTest { get; } = 3;
+    public static int DefaultRunCountForLatencyTest { get; } = 30;
     public static int DefaultRunCountForThroughputTest { get; } = 30;
     public static int[] DefaultCpuSet { get; } = Enumerable.Range(0, Environment.ProcessorCount).ToArray();
 

--- a/src/Disruptor/Disruptor.csproj
+++ b/src/Disruptor/Disruptor.csproj
@@ -27,8 +27,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory" Version="4.5.4"/>
+    <PackageReference Include="System.Memory" Version="4.6.3"/>
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0"/>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Disruptor/Processing/EventProcessor.cs
+++ b/src/Disruptor/Processing/EventProcessor.cs
@@ -135,7 +135,7 @@ public class EventProcessor<T, TPublishedSequenceReader, TEventHandler, TOnBatch
             }
             catch (Exception ex)
             {
-                var evt = dataAccessor[nextSequence];
+                var evt = _dataProvider[nextSequence];
                 _exceptionHandler.HandleEventException(ex, nextSequence, evt);
                 _sequence.SetValue(nextSequence);
                 nextSequence++;

--- a/src/Disruptor/Processing/EventProcessor.cs
+++ b/src/Disruptor/Processing/EventProcessor.cs
@@ -102,7 +102,7 @@ public class EventProcessor<T, TPublishedSequenceReader, TEventHandler, TOnBatch
     private void ProcessEvents(CancellationToken cancellationToken)
     {
         var nextSequence = _sequence.Value + 1L;
-
+        var dataAccessor = _dataProvider.GetAccessor();
         while (true)
         {
             try
@@ -122,7 +122,7 @@ public class EventProcessor<T, TPublishedSequenceReader, TEventHandler, TOnBatch
 
                 while (nextSequence <= availableSequence)
                 {
-                    var evt = _dataProvider[nextSequence];
+                    var evt = dataAccessor[nextSequence];
                     _eventHandler.OnEvent(evt, nextSequence, nextSequence == availableSequence);
                     nextSequence++;
                 }
@@ -135,7 +135,7 @@ public class EventProcessor<T, TPublishedSequenceReader, TEventHandler, TOnBatch
             }
             catch (Exception ex)
             {
-                var evt = _dataProvider[nextSequence];
+                var evt = dataAccessor[nextSequence];
                 _exceptionHandler.HandleEventException(ex, nextSequence, evt);
                 _sequence.SetValue(nextSequence);
                 nextSequence++;

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -148,14 +148,7 @@ public sealed class RingBuffer<T> : RingBuffer, IDataProvider<T>, ISequenced
     public T this[long sequence]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-#if NET
-            return InternalUtil.Read<T>(_entries, (nint)(uint)_bufferPadRef + (sequence & _indexMask));
-#else
-            return InternalUtil.Read<T>(_entries, _bufferPadRef + (int)(sequence & _indexMask));
-#endif
-        }
+        get => InternalUtil.Read<T>(_entries, _bufferPadRef + (int)(sequence & _indexMask));
     }
 
     internal ReadOnlySpan<T> this[long lo, long hi]

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -539,16 +539,16 @@ public sealed class RingBuffer<T> : RingBuffer, IDataProvider<T>, ISequenced
 
     internal readonly ref struct RingBufferAccessor
     {
-        private readonly long _indexMask;
+
 #if NET8_0_OR_GREATER
         private readonly ref T _start;
 #else
         private readonly object _entries;
 #endif
-
+        private readonly uint _indexMask;
         public RingBufferAccessor(object entries, long indexMask)
         {
-            _indexMask = indexMask;
+            _indexMask = (uint)indexMask;
 #if NET8_0_OR_GREATER
             _start = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(entries)), (uint)_bufferPadRef);
 #else
@@ -562,7 +562,7 @@ public sealed class RingBuffer<T> : RingBuffer, IDataProvider<T>, ISequenced
             get
             {
 #if NET8_0_OR_GREATER
-                return Unsafe.Add(ref _start, (nint)(sequence & _indexMask));
+                return Unsafe.Add(ref _start, (uint)(sequence & _indexMask));
 #else
                 return InternalUtil.Read<T>(_entries, _bufferPadRef + (int)(sequence & _indexMask));
 #endif

--- a/src/Disruptor/RingBuffer`1.cs
+++ b/src/Disruptor/RingBuffer`1.cs
@@ -149,7 +149,11 @@ public sealed class RingBuffer<T> : RingBuffer, IDataProvider<T>, ISequenced
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
+#if NET
+            return InternalUtil.Read<T>(_entries, (nint)(uint)_bufferPadRef + (sequence & _indexMask));
+#else
             return InternalUtil.Read<T>(_entries, _bufferPadRef + (int)(sequence & _indexMask));
+#endif
         }
     }
 

--- a/src/Disruptor/Util/InternalUtil.cs
+++ b/src/Disruptor/Util/InternalUtil.cs
@@ -49,29 +49,6 @@ internal static class InternalUtil
     }
 #pragma warning restore 618
 
-#if NET
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T Read<T>(object array, int index)
-        => Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T Read<T>(object array, long index)
-        => Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (nint)index);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ReadOnlySpan<T> ReadSpan<T>(object? array, int index, int length)
-        => array is null ? default : MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index), length);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T ReadValue<T>(object array, int index)
-        => ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ref T ReadValue<T>(IntPtr pointer, int index, int size)
-        where T : struct
-        => ref Unsafe.AddByteOffset(ref Unsafe.AsRef<T>((void*)pointer), (uint)(index * size));
-
-#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T Read<T>(object array, int index)
         where T : class
@@ -172,7 +149,6 @@ internal static class InternalUtil
 
         throw IL.Unreachable();
     }
-#endif
 
     public static int SizeOf<T>()
         where T : struct

--- a/src/Disruptor/Util/InternalUtil.cs
+++ b/src/Disruptor/Util/InternalUtil.cs
@@ -43,10 +43,35 @@ internal static class InternalUtil
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => sizeof(IntPtr) == 4
             ? RuntimeHelpers.OffsetToStringData == 8 ? 8 : 16
-            : RuntimeHelpers.OffsetToStringData == 12 ? 16 : 32;
+            : RuntimeHelpers.OffsetToStringData == 12
+                ? 16
+                : 32;
     }
 #pragma warning restore 618
 
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Read<T>(object array, int index)
+        => Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Read<T>(object array, long index)
+        => Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (nint)index);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<T> ReadSpan<T>(object array, int index, int length)
+        => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index), length);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref T ReadValue<T>(object array, int index)
+        => ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe ref T ReadValue<T>(IntPtr pointer, int index, int size)
+        where T : struct
+        => ref Unsafe.AddByteOffset(ref Unsafe.AsRef<T>((void*)pointer), (uint)(index * size));
+
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T Read<T>(object array, int index)
         where T : class
@@ -147,6 +172,7 @@ internal static class InternalUtil
 
         throw IL.Unreachable();
     }
+#endif
 
     public static int SizeOf<T>()
         where T : struct

--- a/src/Disruptor/Util/InternalUtil.cs
+++ b/src/Disruptor/Util/InternalUtil.cs
@@ -59,8 +59,8 @@ internal static class InternalUtil
         => Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (nint)index);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ReadOnlySpan<T> ReadSpan<T>(object array, int index, int length)
-        => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index), length);
+    public static ReadOnlySpan<T> ReadSpan<T>(object? array, int index, int length)
+        => array is null ? default : MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(array)), (uint)index), length);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T ReadValue<T>(object array, int index)


### PR DESCRIPTION
It's hard to validate the changes for overall performance, but the first commit should be not worse, and ObjectArrayBenchmarks shows an improvement. One of the goals is to remove manual IL, it's hard to maintain. But netstandard2.1 does not have GetArrayDataReference method.

The second commit must work, especially on .NET 8+.